### PR TITLE
Fixed typo discussed in class

### DIFF
--- a/problem-sets/set01.tex
+++ b/problem-sets/set01.tex
@@ -49,7 +49,7 @@ of $M_f$.
   \item between $a_k$ and $a_{k+1}$,
   \item between $b_k$ and $b_{k+1}$,
   \item between $a_k$ and $b_k$, for each $k \in \Z$.
-  \end{itemize} Compute $H^\star(X;\Z)$ and $H^\star(X;\Z)$.  Are they
+  \end{itemize} Compute $H_\star(X;\Z)$ and $H^\star(X;\Z)$.  Are they
 torsion-free?  Are they the same?
 \end{problem}
 


### PR DESCRIPTION
There were two mentions of H^\star where one of them should have been H_\star.